### PR TITLE
Added the aliases in the visualizer graph

### DIFF
--- a/DataCollector/DiDataCollector.php
+++ b/DataCollector/DiDataCollector.php
@@ -42,7 +42,27 @@ class DiDataCollector extends DataCollector
         $services = array();
         foreach ($container->getDefinitions() as $id => $definition) {
             $services[$id] = array(
+                'alias'         => false,
                 'public'        => $definition->isPublic(),
+                'dependencies'  => array(array(), array()),
+            );
+
+            if ($graph->hasNode($id)) {
+                $node = $graph->getNode($id);
+
+                foreach ($node->getInEdges() as $edge) {
+                    $services[$id]['dependencies'][0][] = $edge->getSourceNode()->getId();
+                }
+
+                foreach ($node->getOutEdges() as $edge) {
+                    $services[$id]['dependencies'][1][] = $edge->getDestNode()->getId();
+                }
+            }
+        }
+        foreach ($container->getAliases() as $id => $alias) {
+            $services[$id] = array(
+                'alias'         => true,
+                'public'        => $alias->isPublic(),
                 'dependencies'  => array(array(), array()),
             );
 


### PR DESCRIPTION
This adds the aliases in the graph according to my comment in #2
The `alias` key of the array is there to allow you to make a visual difference which is not implemented in the PR as I don't want to change a minified version :)
