### PR TITLE
Fixed container injection in the data collector

### DIFF
--- a/DataCollector/DiDataCollector.php
+++ b/DataCollector/DiDataCollector.php
@@ -3,6 +3,7 @@
 namespace JMS\DebuggingBundle\DataCollector;
 
 use JMS\DebuggingBundle\DependencyInjection\TraceableContainer;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Compiler\AnalyzeServiceReferencesPass;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpFoundation\Response;
@@ -12,6 +13,11 @@ class DiDataCollector extends DataCollector
 {
     private $container;
     private $containerBuilder;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
 
     public function collect(Request $request, Response $response, \Exception $ex = null)
     {

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -17,7 +17,7 @@
 
     <services>
         <service id="jms.debugging.di_collector" class="%jms.debugging.di_collector.class%" public="false">
-            <property name="container" type="service" id="service_container" />
+            <argument type="service" id="service_container" />
             <tag name="data_collector" template="JMSDebuggingBundle:Collector:container" id="dependency_injection" />
         </service>
         <service id="jms.debugging.exception_collector" class="%jms.debugging.exception_collector.class%" public="false">


### PR DESCRIPTION
The container is now injected through constructor since protected and private properties injection has been removed in the symfony core.
