### PR TITLE
Fix constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.*"
+        "symfony/framework-bundle": "2.*"
     },
     "autoload": {
         "psr-0": { "JMS\\DebuggingBundle": "" }


### PR DESCRIPTION
Really IMO this should be `>=2.0,<2.2-dev`, but at least this one will allow it to be crawled by packagist.
