### PR TITLE
Fix exception on no firewall listeners

### DIFF
--- a/DataCollector/SecurityDataCollector.php
+++ b/DataCollector/SecurityDataCollector.php
@@ -26,7 +26,7 @@ class SecurityDataCollector extends BaseSecurityDataCollector
         $listeners = array();
         $listenerTrace = $this->firewall->getListenerTrace();
         $handlingListener = $this->firewall->getHandlingListener();
-        foreach ($this->firewall->getListeners() as $listener) {
+        foreach ($this->firewall->getListeners() ?: array() as $listener) {
             $data = array(
                 'class' => $class = get_class($listener),
                 'short_name' => substr($class, strrpos($class, '\\') + 1),


### PR DESCRIPTION
If a redirect is triggered before the firewall has started up the security collector causes a warning due to there being no firewall listeners. I think the reason this hasn't been picked up to this point is that it isn't a very common use case, however it does occur with the Nelmio Security Bundle.

`$this->firewall->getListeners()` returns null if the firewall has not yet started, resulting in a warning:

`Warning: Invalid argument supplied for foreach()`

This patch prevents the issue.
