### PR TITLE
Update symfony/framework-bundle requirement for 2.* support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.0,<2.3-dev"
+        "symfony/framework-bundle": "2.*"
     },
     "autoload": {
         "psr-0": { "JMS\\DebuggingBundle": "" }


### PR DESCRIPTION
As bundle supports symfony 2.0, current version is 2.3 and symfony should save BC for 2.\* versions.
