### PR TITLE
Fix compatibility with Symfony 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "~2.3"
+        "symfony/framework-bundle": "~2.0"
     },
     "autoload": {
         "psr-0": { "JMS\\DebuggingBundle": "" }


### PR DESCRIPTION
Note that due to an interface break in symfony, you will either need to:
a) support symfony >=2.3
b) reject this PR (or changes) and support symfony < 2.3

note: fixes issues raised only in #71
