### PR TITLE
Fxes a bug when a service is null, Issue #70

### DIFF
--- a/DependencyInjection/TraceableContainer.php
+++ b/DependencyInjection/TraceableContainer.php
@@ -22,7 +22,10 @@ class TraceableContainer extends Container
 
         $id = strtolower($id);
         $rs = parent::set($id, $service, $scope);
-        $this->returnedServices->offsetSet($service, $id);
+
+        if (is_object($service)) {
+            $this->returnedServices->offsetSet($service, $id);
+        }
 
         return $rs;
     }


### PR DESCRIPTION
The service can be null when a requested with the argument $invalid = ContainerInterface::NULL_ON_INVALID_REFERENCE.
This is solved issue #70
