### PR TITLE
Fix changes between symfony 2.1/2.2

### DIFF
--- a/HttpFoundation/TraceableRequestMatcher.php
+++ b/HttpFoundation/TraceableRequestMatcher.php
@@ -65,14 +65,17 @@ class TraceableRequestMatcher extends RequestMatcher
             return false;
         }
 
-        // Support old Symfony 2.1 way of doing things.
+        // Symfony <= 2.2
         if (property_exists('Symfony\Component\HttpFoundation\RequestMatcher', 'ip')) {
             $ips = array($this->getFieldValue('ip'));
-            $checkIpClass = 'Symfony\Component\HttpFoundation\RequestMatcher';
-
-        // Support new Symfony 2.3 way of doing things.
         } else {
             $ips = $this->getFieldValue('ips');
+        }
+
+        // Symfony <= 2.1
+        if (!class_exists('Symfony\Component\HttpFoundation\IpUtils')) {
+            $checkIpClass = 'Symfony\Component\HttpFoundation\RequestMatcher';
+        } else {
             $checkIpClass = 'Symfony\Component\HttpFoundation\IpUtils';
         }
 


### PR DESCRIPTION
I realized today that the changes inside HttpFoundation _weren't_ done at the same time between Symfony updates. My fault.

Anyhow, here are the changes.

The bundle is still broken, however. I'll do some poking around, but the bundle seems to be causing the firewall to trigger at all times, but with no auth token of any kind, symfony errors out.

```
     [exec] Caused by
     [exec] Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException: The security context contains no authentication token. One possible reason may be that there is no firewall configured for this URL.
```

My knowledge of Symfony Firewall is a limited one. If I can't find the solution to the problem, I'll probably open up another issue just to track it.
